### PR TITLE
Fix kill queue

### DIFF
--- a/lib/assembly/ar_computed.py
+++ b/lib/assembly/ar_computed.py
@@ -157,17 +157,16 @@ def start_kill_monitor(rmq_host, rmq_port):
     channel.start_consuming()
 
 def kill_callback(ch, method, properties, body):
-        print " [x] %r" % (body,)
-        kill_request = json.loads(body)
-        print 'job_list:', job_list
-        job_list_lock.acquire()
-        kill_list_lock.acquire()
-        for job_data in job_list:
-            if kill_request['user'] == job_data['user'] and kill_request['job_id'] == str(job_data['job_id']):
-                print 'on this node'
-                kill_list.append(kill_request)
-        kill_list_lock.release()
-        job_list_lock.release()
+    kill_request = json.loads(body)
+    print 'job_list:', job_list
+    job_list_lock.acquire()
+    kill_list_lock.acquire()
+    for job_data in job_list:
+        if kill_request['user'] == job_data['user'] and kill_request['job_id'] == str(job_data['job_id']):
+            print 'on this node'
+            kill_list.append(kill_request)
+    kill_list_lock.release()
+    job_list_lock.release()
 
 
 parser = argparse.ArgumentParser(prog='ar_computed', epilog='Use "arast command -h" for more information about a command.')

--- a/lib/assembly/consume.py
+++ b/lib/assembly/consume.py
@@ -202,6 +202,8 @@ class ArastConsumer:
         return datapath, all_files
 
     def compute(self, body):
+        print 'compute'
+        self.job_list_lock.acquire()
         error = False
         params = json.loads(body)
         job_id = params['job_id']
@@ -255,7 +257,7 @@ class ArastConsumer:
                     'out_report' : self.out_report})
 
         self.out_report.write("Arast Pipeline: Job {}\n".format(job_id))
-        self.job_list_lock.acquire()
+
         try:
             self.job_list.append(job_data)
         except:
@@ -307,29 +309,6 @@ class ArastConsumer:
             w_engine.run_expression(wasp_exp, job_data)
             ###### Upload all result files and place them into appropriate tags
             uploaded_fsets = job_data.upload_results(url, token)
-
-            self.job_list_lock.acquire()
-            try:
-                for i, job in enumerate(self.job_list):
-                    if job['user'] == job_data['user'] and job['job_id'] == job_data['job_id']:
-                        self.job_list.pop(i)
-            except:
-                logging.error("Unexpected error in removing executed jobs from job_list")
-                raise
-            finally:
-                self.job_list_lock.release()
-
-            # kill_list cleanup for cases where a kill request is enqueued right before the corresponding job gets popped
-            self.kill_list_lock.acquire()
-            try:
-                for i, kill_request in enumerate(self.kill_list):
-                    if kill_request['user'] == job_data['user'] and kill_request['job_id'] == job_data['job_id']:
-                        self.kill_list.pop(i)
-            except:
-                logging.error("Unexpected error in removing executed jobs from kill_list")
-                raise
-            finally:
-                self.kill_list_lock.release()
 
             # Format report
             new_report = open('{}.tmp'.format(self.out_report_name), 'w')
@@ -389,6 +368,31 @@ class ArastConsumer:
         except asmtypes.ArastUserInterrupt:
             status = 'Terminated by user'
             print '============== JOB KILLED ==============='
+        finally:
+            self.job_list_lock.acquire()
+            try:
+                for i, job in enumerate(self.job_list):
+                    if job['user'] == job_data['user'] and job['job_id'] == job_data['job_id']:
+                        self.job_list.pop(i)
+            except:
+                logging.error("Unexpected error in removing executed jobs from job_list")
+                raise
+            finally:
+                self.job_list_lock.release()
+
+            # kill_list cleanup for cases where a kill request is enqueued right before the corresponding job gets popped
+            self.kill_list_lock.acquire()
+            try:
+                for i, kill_request in enumerate(self.kill_list):
+                    if kill_request['user'] == job_data['user'] and kill_request['job_id'] == job_data['job_id']:
+                        self.kill_list.pop(i)
+            except:
+                logging.error("Unexpected error in removing executed jobs from kill_list")
+                raise
+            finally:
+                self.kill_list_lock.release()
+
+
         self.metadata.update_job(uid, 'status', status)
 
     def upload(self, url, user, token, file, filetype='default'):


### PR DESCRIPTION
There is still a case where the kill command can miss:

1. `ar-run -f BIG_FILE`
2. `ar-kill -j JOB`
3. job is "Queued" in mongo, but routing to a compute node.  We now still publish the kill command to catch this.
4. kill request callback checks to see if kill_id is in job_list, but job isn't added to job_list until after data transfer, thus, skips the kill queue.

So, I moved the lock_acquire back to before file transfer.  This will only allow one thread to transfer at a time, like we discussed.  Do you see any downside to this?

Also, there was a bug where jobs weren't popped from job_list on terminate/exception.  Moved this to a `finally` statement.