### PR TITLE
Ensure index on user and jobid

### DIFF
--- a/lib/assembly/metadata.py
+++ b/lib/assembly/metadata.py
@@ -26,6 +26,10 @@ class MetadataConnection:
 
         # Get local data
         self.jobs = self.get_jobs()
+
+        # Ensure compound index
+        self.jobs.ensure_index([("ARASTUSER", pymongo.ASCENDING), ("job_id", pymongo.ASCENDING)])
+
         self.data_collection = self.get_data()
 
     def get_jobs(self):


### PR DESCRIPTION
This should do the trick.  You only need to ensure index once, but it is idempotent so there's no harm in calling it on every init.

My dev mongo shows that it worked:

```
> db.jobs.getIndexes()
[
        {
                "v" : 1,
                "key" : {
                        "_id" : 1
                },
                "ns" : "arast.jobs",
                "name" : "_id_"
        },
        {
                "v" : 1,
                "key" : {
                        "ARASTUSER" : 1,
                        "job_id" : 1
                },
                "ns" : "arast.jobs",
                "name" : "ARASTUSER_1_job_id_1"
        }
]
```