### PR TITLE
Fasta files and Auto recipe compatibility

### DIFF
--- a/lib/assembly/recipes/auto.lisp
+++ b/lib/assembly/recipes/auto.lisp
@@ -3,6 +3,9 @@
 ;;; 3. Sorts assemblies by ALE score
 (begin
   (define pp (bhammer READS))
+  (if (not (symbol? pp))
+      (prog
+       (define pp READS)))
   (define vt (velvet pp))
   (define sp (spades pp))
   (if (has_paired READS)

--- a/lib/assembly/recipes/auto.lisp
+++ b/lib/assembly/recipes/auto.lisp
@@ -4,8 +4,7 @@
 (begin
   (define pp (bhammer READS))
   (if (not (symbol? pp))
-      (prog
-       (define pp READS)))
+      (define pp READS))
   (define vt (velvet pp))
   (define sp (spades pp))
   (if (has_paired READS)

--- a/lib/assembly/wasp.py
+++ b/lib/assembly/wasp.py
@@ -103,8 +103,16 @@ def eval(x, env):
     ##################################
 
     elif x[0] == 'if':             # (if test conseq alt)
-        (_, test, conseq, alt) = x
-        return eval((conseq if eval(test, env) else alt), env)
+        if len(x) == 4:
+            (_, test, conseq, alt) = x
+        elif len(x) == 3:
+            (_, test, conseq) = x
+            alt = None
+        if eval(test, env):
+            return eval(conseq, env)
+        elif alt:
+            return eval(alt, env)
+            
     elif x[0] == 'set!':           # (set! var exp)
         (_, var, exp) = x
         env.find(var)[var] = eval(exp, env)
@@ -120,8 +128,8 @@ def eval(x, env):
         except Exception as e: 
             print ' [!] Failed to evaluate definition of "{}": {}'.format(var, e)
             print traceback.format_exc()
-            env.errors.append(e)
-            env.exceptions.append(traceback.format_exc())
+            # env.errors.append(e)
+            # env.exceptions.append(traceback.format_exc())
             env[var] = None
     elif x[0] == 'sort':
         seq = [link for link in eval(x[1], env) if link is not None and link.output]
@@ -220,6 +228,10 @@ def eval(x, env):
                     env.exceptions.append(traceback.format_exc())
         if val:
             return val if len(val) > 1 else val[0]
+
+    elif x[0] == 'print':
+        for exp in x[1:]:
+            print eval(exp, env)
     elif x[0] == 'prog':          # same as begin, but use same env
         val = []
         for exp in x[1:]:


### PR DESCRIPTION
Addressing #301 

The auto recipe now checks to see if BayesHammer was successful (whether `pp` was defined).  If not, uses the initial reads.

I think this is the right way to go... this sort of logic should be explicit in the Wasp expression.