### PR TITLE
Contig support

### DIFF
--- a/client/arast.py
+++ b/client/arast.py
@@ -64,6 +64,7 @@ def get_parser():
     p_upload.add_argument("--single_url", action="append", dest="single_url", nargs='*', help="Specify a URL for a single end file and parameters")
     p_upload.add_argument("--reference", action="append", dest="reference", nargs='*', help="specify a reference contig file")
     p_upload.add_argument("--reference_url", action="append", dest="reference_url", nargs='*', help="Specify a URL for a reference contig file and parameters")
+    p_upload.add_argument("--contigs", action="append", dest="contigs", nargs='*', help="specify a contig file")
     p_upload.add_argument("-m", "--message", action="store", dest="message", help="Attach a description to job")
     p_upload.add_argument("--curl", action="store_true", help="Use curl for http requests")
     p_upload.add_argument("--json", action="store_true", help="Print data info json object")
@@ -78,6 +79,7 @@ def get_parser():
     p_run.add_argument("--single_url", action="append", dest="single_url", nargs='*', help="Specify a URL for a single end file and parameters")
     p_run.add_argument("--reference", action="append", dest="reference", nargs='*', help="specify sequence file(s)")
     p_run.add_argument("--reference_url", action="append", dest="reference_url", nargs='*', help="Specify a URL for a reference contig file and parameters")
+    p_run.add_argument("--contigs", action="append", dest="contigs", nargs='*', help="specify a contig file")
     p_run.add_argument("--curl", action="store_true", help="Use curl for http requests")
 
     data_group = p_run.add_mutually_exclusive_group()
@@ -276,7 +278,7 @@ def cmd_avail(args, aclient):
 def prepare_assembly_data(args, aclient, usage):
     """Parses args and uploads files
     returns data spec for submission in run/upload commands"""
-    if not (args.pair or args.single or args.pair_url or args.single_url):
+    if not (args.pair or args.single or args.pair_url or args.single_url or args.contigs):
         sys.exit(usage)
 
     adata = client.AssemblyData()
@@ -289,9 +291,9 @@ def prepare_assembly_data(args, aclient, usage):
     file_lists = []
 
     all_lists = [args.pair, args.pair_url, args.single, args.single_url,
-                 args.reference, args.reference_url]
+                 args.reference, args.reference_url, args.contigs]
     all_types = ['paired', 'paired_url', 'single', 'single_url',
-                 'reference', 'reference_url']
+                 'reference', 'reference_url', 'contigs']
 
     for li in all_lists:
         if li is None:

--- a/lib/assembly/ar_computed.py
+++ b/lib/assembly/ar_computed.py
@@ -95,7 +95,8 @@ def start(arasturl, config, num_threads, queue, datapath, binpath, modulebin):
     # Check MongoDB status
     logger.info("[.] Connecting to MongoDB server...")
     try:
-        connection = pymongo.Connection(mongo_host, mongo_port)
+        #connection = pymongo.Connection(mongo_host, mongo_port)
+        connection = pymongo.mongo_client.MongoClient(mongo_host, mongo_port)
         connection.close()
         logger.debug("MongoDB Info: %s" % connection.server_info())
     except pymongo.errors.PyMongoError as e:
@@ -217,10 +218,10 @@ binpath = args.binpath or None
 modulebin = args.modulebin or None
 logfile = args.logfile or 'ar_compute.log'
 
-utils.verify_dir(os.path.dirname(logfile))
+# utils.verify_dir(os.path.dirname(logfile))
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s %(process)d %(name)s] %(message)s",
-                    datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO, filename=logfile)
+                    datefmt="%Y-%m-%d %H:%M:%S", level=logging.DEBUG, filename=logfile)
 
 if args.verbose:
     logging.root.setLevel(logging.DEBUG)

--- a/lib/assembly/ar_computed.py
+++ b/lib/assembly/ar_computed.py
@@ -95,7 +95,6 @@ def start(arasturl, config, num_threads, queue, datapath, binpath, modulebin):
     # Check MongoDB status
     logger.info("[.] Connecting to MongoDB server...")
     try:
-        #connection = pymongo.Connection(mongo_host, mongo_port)
         connection = pymongo.mongo_client.MongoClient(mongo_host, mongo_port)
         connection.close()
         logger.debug("MongoDB Info: %s" % connection.server_info())
@@ -218,7 +217,8 @@ binpath = args.binpath or None
 modulebin = args.modulebin or None
 logfile = args.logfile or 'ar_compute.log'
 
-# utils.verify_dir(os.path.dirname(logfile))
+if os.path.dirname(logfile):
+    utils.verify_dir(os.path.dirname(logfile))
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s %(process)d %(name)s] %(message)s",
                     datefmt="%Y-%m-%d %H:%M:%S", level=logging.DEBUG, filename=logfile)

--- a/lib/assembly/arast.conf
+++ b/lib/assembly/arast.conf
@@ -25,7 +25,9 @@ mongo.collection.data = data
 
 #### Storage ####
 [shock]
-host = 140.221.67.235:7445
+#host = 140.221.67.235:7445
+host = 10.1.28.25:7445
+#host = http://kbase.us/services/assembly/shock
 
 [web_serve]
 root = /mnt/web/

--- a/lib/assembly/arast.conf
+++ b/lib/assembly/arast.conf
@@ -25,9 +25,7 @@ mongo.collection.data = data
 
 #### Storage ####
 [shock]
-#host = 140.221.67.235:7445
-host = 10.1.28.25:7445
-#host = http://kbase.us/services/assembly/shock
+host = http://kbase.us/services/assembly/shock
 
 [web_serve]
 root = /mnt/web/

--- a/lib/assembly/arastd.py
+++ b/lib/assembly/arastd.py
@@ -61,8 +61,8 @@ def start(config_file, shock_url=None, mongo_host=None, mongo_port=None,
 
     # Check MongoDB status
     try:
-        connection = pymongo.Connection(mongo_host, mongo_port)
-        logger.debug("MongoDB Info: %s" % connection.server_info())
+        connection = pymongo.mongo_client.MongoClient(mongo_host, mongo_port)
+        logging.info("MongoDB Info: %s" % connection.server_info())
     except pymongo.errors.PyMongoError as e:
         logger.error("MongoDB connection error: {}".format(e))
         sys.exit('MongoDB error: {}'.format(e))
@@ -118,7 +118,7 @@ parser.add_argument("-c", "--config", help="specify the config file",
 
 args = parser.parse_args()
 
-logfile = args.logfile or 'ar_compute.log'
+logfile = args.logfile or 'ar_server.log'
 utils.verify_dir(os.path.dirname(logfile))
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s %(name)s] %(message)s",

--- a/lib/assembly/asmtypes.py
+++ b/lib/assembly/asmtypes.py
@@ -63,7 +63,7 @@ class FileSet(dict):
 
     @property
     def name(self):
-        return self['name'] or None
+        return self.get('name')
 
     @property
     def type(self):

--- a/lib/assembly/client.py
+++ b/lib/assembly/client.py
@@ -199,7 +199,6 @@ class Client:
 
     def req(self, url, req_type='get', data=None, ret=None):
         """Authenticated request. Parses CherryPy message and raises HTTPError"""
-        # print "req_{}: {}".format(req_type, url)
         try:
             if req_type == 'get':
                 r = requests.get(url, headers=self.headers)

--- a/lib/assembly/consume.py
+++ b/lib/assembly/consume.py
@@ -276,6 +276,7 @@ class ArastConsumer:
         ### Create data to pass to pipeline
         reads = []
         reference = []
+        contigs = []
         for fileset in all_files:
             if len(fileset['files']) != 0:
                 if (fileset['type'] == 'single' or
@@ -283,6 +284,8 @@ class ArastConsumer:
                     reads.append(fileset)
                 elif fileset['type'] == 'reference':
                     reference.append(fileset)
+                elif fileset['type'] == 'contigs':
+                    contigs.append(fileset)
                 else:
                     raise Exception('fileset error')
 
@@ -292,6 +295,7 @@ class ArastConsumer:
                     'reads': reads,
                     'logfiles': [],
                     'reference': reference,
+                    'contigs': contigs,
                     'initial_reads': list(reads),
                     'raw_reads': copy.deepcopy(reads),
                     'params': [],

--- a/lib/assembly/job.py
+++ b/lib/assembly/job.py
@@ -158,7 +158,7 @@ class ArastJob(dict):
         """
         all_sets = []
         #### Convert Old Reads Format to ReadSets
-        for set_type in ['reads', 'reference']:
+        for set_type in ['reads', 'reference', 'contigs']:
             if set_type in self:
                 for fs in self[set_type]:
                     ### Get supported set attributes (ins, std, etc)

--- a/lib/assembly/metadata.py
+++ b/lib/assembly/metadata.py
@@ -25,7 +25,6 @@ class MetadataConnection:
 
         # Connect
         self.connection = pymongo.mongo_client.MongoClient(self.host, self.port)
-        #self.connection = pymongo.Connection(self.host, self.port)
         self.database = self.connection[self.db]
 
         # Get local data
@@ -52,14 +51,12 @@ class MetadataConnection:
         return job_id
 
     def insert_doc(self, collection, data):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         col = database[collection]
         col.insert(data)
 
     def list (self, collection):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         col = database[collection]
@@ -68,14 +65,12 @@ class MetadataConnection:
         return col.find({})
 
     def remove_doc(self, collection, key, value):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         col = database[collection]
         col.remove({key:value})
 
     def update_doc(self, collection, query_key, query_value, key, value):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         col = database[collection]
@@ -89,7 +84,6 @@ class MetadataConnection:
 
 
     def get_next_id(self, user, category):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         ids = database[category]
@@ -144,7 +138,6 @@ class MetadataConnection:
         return job['status'].find('success') != -1
 
     def get_auth_info(self, user):
-        #connection = pymongo.Connection(self.host, self.port)
         connection = self.connection
         database = connection[self.db]
         col = database[self.auth_collection]

--- a/lib/assembly/metadata.py
+++ b/lib/assembly/metadata.py
@@ -24,7 +24,8 @@ class MetadataConnection:
         self.rjobs_collection = collections.get('running')
 
         # Connect
-        self.connection = pymongo.Connection(self.host, self.port)
+        self.connection = pymongo.mongo_client.MongoClient(self.host, self.port)
+        #self.connection = pymongo.Connection(self.host, self.port)
         self.database = self.connection[self.db]
 
         # Get local data
@@ -51,13 +52,15 @@ class MetadataConnection:
         return job_id
 
     def insert_doc(self, collection, data):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         col = database[collection]
         col.insert(data)
 
     def list (self, collection):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         col = database[collection]
         for r in col.find({}):
@@ -65,13 +68,15 @@ class MetadataConnection:
         return col.find({})
 
     def remove_doc(self, collection, key, value):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         col = database[collection]
         col.remove({key:value})
 
     def update_doc(self, collection, query_key, query_value, key, value):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         col = database[collection]
 
@@ -84,7 +89,8 @@ class MetadataConnection:
 
 
     def get_next_id(self, user, category):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         ids = database[category]
         next_id = 1
@@ -138,7 +144,8 @@ class MetadataConnection:
         return job['status'].find('success') != -1
 
     def get_auth_info(self, user):
-        connection = pymongo.Connection(self.host, self.port)
+        #connection = pymongo.Connection(self.host, self.port)
+        connection = self.connection
         database = connection[self.db]
         col = database[self.auth_collection]
         try:

--- a/lib/assembly/plugins.py
+++ b/lib/assembly/plugins.py
@@ -91,7 +91,6 @@ class BasePlugin(object):
             cmd_string = human_readable_command(cmd_args)
         else:
             cmd_string = cmd_args
-
         if cmd_args[0].find('..') != -1 and not shell:
             raise Exception("Plugin Config not updated: {}".format(cmd_args[0]))
 
@@ -101,7 +100,6 @@ class BasePlugin(object):
         except Exception as e:
             logger.error('Could not write to report: {} -- {}'.format(cmd_string, e))
         m_start_time = time.time()
-        # print "Command args: {}".format(cmd_args)
         logger.info("Command line: {}".format(cmd_string if shell else " ".join(cmd_args)))
         try:
             env_copy = os.environ.copy()
@@ -257,7 +255,6 @@ class BasePlugin(object):
         out_internal = open('{}.{}'.format(self.out_module.name, self.name), 'w')
         plugin_data['out_report'] = self.out_report
         self.plugin_engine = wasp.WaspEngine(self.pmanager, plugin_data)
-
         #### Get default outputs of last module and pass on persistent data
         job_data['wasp_chain']['outpath'] = self.outpath
         if job_data['wasp_chain']['link']:

--- a/lib/assembly/plugins/quast.py
+++ b/lib/assembly/plugins/quast.py
@@ -6,15 +6,15 @@ from plugins import BaseAssessment
 from yapsy.IPlugin import IPlugin
 import asmtypes
 
+import traceback
+
 logger = logging.getLogger(__name__)
 
 class QuastAssessment(BaseAssessment, IPlugin):
     new_version = True
 
     def run(self):
-
         contigsets = self.data.contigsets
-
         for i,c, in enumerate(contigsets):
             c['tags'].append('quast-{}'.format(i+1))
         contigfiles = self.data.contigfiles
@@ -41,9 +41,10 @@ class QuastAssessment(BaseAssessment, IPlugin):
 
         #### Add Contig files ####
         cmd_args += contigfiles
-        cmd_args += ['-l', '"{}"'.format(', '.join([cset.name for cset in contigsets]))]
-
-
+        try:
+            cmd_args += ['-l', '"{}"'.format(', '.join([cset.name for cset in contigsets]))]
+        except (KeyError, TypeError): # No name
+            pass
         #### Run Quast ####
         self.arast_popen(cmd_args)
 

--- a/lib/assembly/plugins/quast.py
+++ b/lib/assembly/plugins/quast.py
@@ -43,8 +43,9 @@ class QuastAssessment(BaseAssessment, IPlugin):
         cmd_args += contigfiles
         try:
             cmd_args += ['-l', '"{}"'.format(', '.join([cset.name for cset in contigsets]))]
-        except (KeyError, TypeError): # No name
+        except TypeError: # Contigset has no names
             pass
+
         #### Run Quast ####
         self.arast_popen(cmd_args)
 

--- a/lib/assembly/plugins/quast.py
+++ b/lib/assembly/plugins/quast.py
@@ -6,8 +6,6 @@ from plugins import BaseAssessment
 from yapsy.IPlugin import IPlugin
 import asmtypes
 
-import traceback
-
 logger = logging.getLogger(__name__)
 
 class QuastAssessment(BaseAssessment, IPlugin):

--- a/lib/assembly/recipes/contig_compare.lisp
+++ b/lib/assembly/recipes/contig_compare.lisp
@@ -1,0 +1,5 @@
+(begin
+ (define contigs CONTIGS)
+ (define newsort (sort (list contigs) > :key (lambda (c) (arast_score c))))
+ (tar (all_files (quast contigs)) :name analysis)
+ )

--- a/lib/assembly/wasp.py
+++ b/lib/assembly/wasp.py
@@ -131,10 +131,6 @@ def eval(x, env):
         except Exception as e:
             logger.error('Failed to evaluate definition of "{}": {}'.format(var, e))
             logger.debug(traceback.format_exc())
-            # print ' [!] Failed to evaluate definition of "{}": {}'.format(var, e)
-            # print traceback.format_exc()
-            # env.errors.append(e)
-            # env.exceptions.append(traceback.format_exc())
             env[var] = None
     elif x[0] == 'sort':
         seq = [link for link in eval(x[1], env) if link is not None and link.output]
@@ -165,8 +161,6 @@ def eval(x, env):
         except Exception as e:
             logger.warn('Failed to evaluate upload of "{}": {}'. format(to_string(exp), e))
             logger.debug(traceback.format_exc())
-            # print ' [!]: {} -- {}'.format(to_string(exp), e)
-            # print traceback.format_exc()
             env.errors.append(e)
             env.exceptions.append(traceback.format_exc())
             results = None
@@ -232,7 +226,6 @@ def eval(x, env):
                 if list(e):
                     logger.error('Failed to eval "{}": {}'.format(to_string(exp), e))
                     logger.debug(traceback.format_exc())
-                    # print(traceback.format_exc())
                     env.errors.append(e)
                     env.exceptions.append(traceback.format_exc())
         if val:
@@ -252,7 +245,6 @@ def eval(x, env):
                 if list(e):
                     logger.error('Failed to eval "{}": {}'.format(to_string(exp), e))
                     logger.debug(traceback.format_exc())
-                    # print(traceback.format_exc())
                     env.errors.append(e)
                     env.exceptions.append(traceback.format_exc())
         if val:
@@ -425,13 +417,17 @@ class WaspEngine():
         self.assembly_env.update({k:self.get_wasp_func(k, job_data) for k in self.pmanager.plugins})
         self.assembly_env.plugins = self.pmanager.plugins
         self.job_data = job_data
-        init_link = WaspLink()
+        reads_link = WaspLink()
+        contigs_link = WaspLink()
         if 'initial_data' not in job_data:
             job_data['initial_data'] = asmtypes.FileSetContainer(job_data.wasp_data().referencesets +
-                                                                 job_data.wasp_data().readsets)
-        init_link['default_output'] = list(job_data['initial_data'].readsets)
+                                                                 job_data.wasp_data().readsets +
+                                                                 job_data.wasp_data().contigsets)
+        reads_link['default_output'] = list(job_data['initial_data'].readsets)
+        reads_link['default_output'] = list(job_data['initial_data'].contigsets)
 
-        self.assembly_env.update({self.constants_reads: init_link})
+        self.assembly_env.update({self.constants_reads: reads_link})
+        self.assembly_env.update({self.constants_contigs: reads_link})
         self.assembly_env.update({'arast_score': wf.arast_score,
                                   'has_paired': wf.has_paired,
                                   'n50': wf.n50})

--- a/lib/assembly/wasp.py
+++ b/lib/assembly/wasp.py
@@ -424,10 +424,10 @@ class WaspEngine():
                                                                  job_data.wasp_data().readsets +
                                                                  job_data.wasp_data().contigsets)
         reads_link['default_output'] = list(job_data['initial_data'].readsets)
-        reads_link['default_output'] = list(job_data['initial_data'].contigsets)
+        contigs_link['default_output'] = list(job_data['initial_data'].contigsets)
 
         self.assembly_env.update({self.constants_reads: reads_link})
-        self.assembly_env.update({self.constants_contigs: reads_link})
+        self.assembly_env.update({self.constants_contigs: contigs_link})
         self.assembly_env.update({'arast_score': wf.arast_score,
                                   'has_paired': wf.has_paired,
                                   'n50': wf.n50})


### PR DESCRIPTION
Added support in WASP engine for a contig file type.  To be used with recipes/plugins that can use  `self.data.contigfiles`.  

Added a `contigs_compare`recipe that runs quast on all contig files: 
```arast run --contigs contigs1.fa --contigs2.fa --recipe contigs_compare```

Newest version of `pymongo` uses a different connection constructor.  Updated to support that.