### PR TITLE
Compute node support multiple queues

### DIFF
--- a/lib/assembly/ar_computed.py
+++ b/lib/assembly/ar_computed.py
@@ -70,7 +70,7 @@ def start(arasturl, config, num_threads, queue, datapath, binpath, modulebin):
     rmq_port = int(ctrl_conf['assembly']['rabbitmq_port'])
     rmq_host = ctrl_conf['assembly']['rabbitmq_host']
     if not queue:
-        queue = ctrl_conf['rabbitmq']['default_routing_key']
+        queue = [ctrl_conf['rabbitmq']['default_routing_key']]
     if mongo_host == 'localhost':
         mongo_host = arasturl
     if rmq_host == 'localhost':

--- a/lib/assembly/ar_computed.py
+++ b/lib/assembly/ar_computed.py
@@ -210,7 +210,9 @@ parser.add_argument("-m", "--module-bin", dest='modulebin', help="specify a dire
 args = parser.parse_args()
 
 arasturl = args.server or None
-queue = args.queue or None
+queues = []
+if args.queue:
+    queues = args.queue.split(',')
 num_threads = args.threads or None
 datapath = args.datapath or None
 binpath = args.binpath or None
@@ -226,4 +228,4 @@ logging.basicConfig(format="[%(asctime)s %(levelname)s %(process)d %(name)s] %(m
 if args.verbose:
     logging.root.setLevel(logging.DEBUG)
 
-start(arasturl, args.config, num_threads, queue, datapath, binpath, modulebin)
+start(arasturl, args.config, num_threads, queues, datapath, binpath, modulebin)


### PR DESCRIPTION
This should work for multiple queues.  It seems like jobs need to submitted first to create the new queue before attaching will work.
```
./ar_computed ... -q euk,prok
```
