### PR TITLE
Add retry

### DIFF
--- a/lib/assembly/shock.py
+++ b/lib/assembly/shock.py
@@ -248,6 +248,7 @@ class Shock:
         attr_file = self._create_attr_file(tmp_attr, 'attrs')
         cmd = ['curl',
                '-X', 'POST',
+               '--retry', '2',
                '-F', 'attributes=@{}'.format(attr_file),
                '-F', 'upload=@{}'.format(filename),
                '{}/node/'.format(self.shockurl)]


### PR DESCRIPTION
I had a problem with a large submission where shock apparently through a transient error on one of the uploads. This trivial patch adds a "--retry 2" to the curl post; ideally this would probably be a configuration parameter or somesuch.

For your consideration.